### PR TITLE
Fix NRE on game version 12.0.2

### DIFF
--- a/InventoryControl/EventHandlers.cs
+++ b/InventoryControl/EventHandlers.cs
@@ -20,7 +20,7 @@
         [PluginEvent(ServerEventType.PlayerChangeRole)]
         public void OnChangeRole(Player player, PlayerRoleBase oldRole, RoleTypeId newRole, RoleChangeReason reason)
         {
-            if (InventoryControl.Instance.Config.InventoryRank.ContainsKey(ServerStatic.GetPermissionsHandler()._groups.FirstOrDefault(g => EqualsTo(g.Value, player.ReferenceHub.serverRoles.Group)).Key))
+            if (InventoryControl.Instance.Config.InventoryRank.ContainsKey(ServerStatic.GetPermissionsHandler()._groups.First(g => EqualsTo(g.Value, player.ReferenceHub.serverRoles.Group)).Key))
             { SetRankRoleItem(player, newRole); return; }
 
             if (InventoryControl.Instance.Config.Inventory.ContainsKey(newRole)) SetRoleItem(player, newRole);
@@ -83,7 +83,7 @@
                 {
                     if (InventoryControl.Instance.Config.InventoryRank.ContainsKey(ServerStatic.PermissionsHandler._members[player.UserId]))
                     {
-                        if (!InventoryControl.Instance.Config.InventoryRank[ServerStatic.GetPermissionsHandler()._groups.FirstOrDefault(g => EqualsTo(g.Value, player.ReferenceHub.serverRoles.Group)).Key].ContainsKey(player.Role)) return;
+                        if (!InventoryControl.Instance.Config.InventoryRank[ServerStatic.GetPermissionsHandler()._groups.First(g => EqualsTo(g.Value, player.ReferenceHub.serverRoles.Group)).Key].ContainsKey(player.Role)) return;
 
                         Dictionary<ItemType, ushort> Ammo2 = new Dictionary<ItemType, ushort>();
 


### PR DESCRIPTION
Fixes error below:
```
[2023-01-16 19:41:28.209 +01:00] [Error] [PluginAPI] Failed executing event OnChangeRole (PlayerChangeRole) in plugin InventoryControl.InventoryControl
                                 System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object
                                   at InventoryControl.EventHandlers.OnChangeRole (PluginAPI.Core.Player player, PlayerRoles.PlayerRoleBase oldRole, PlayerRoles.RoleTypeId newRole, PlayerRoles.RoleChangeReason reason) [0x0004c] in <44aa72c3f10648cba1653e5df609c6bf>:0 
                                   at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception
                                   at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <9577ac7a62ef43179789031239ba8798>:0 
                                    --- End of inner exception stack trace ---
                                   at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00048] in <9577ac7a62ef43179789031239ba8798>:0 
                                   at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
                                   at PluginAPI.Events.EventInvokeLocation.Invoke (System.Object[] parameters) [0x00000] in <4c2a3c9f04a54612acd3e9a88faf0eba>:0 
                                   at PluginAPI.Events.EventManager.ExecuteEvent[T] (PluginAPI.Enums.ServerEventType type, System.Object[] args) [0x000a3] in <4c2a3c9f04a54612acd3e9a88faf0eba>:0
```